### PR TITLE
Add PSR-17 compatibility layer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "psr/http-message": "^1.0"
+        "php": "^7.2",
+        "psr/http-message": "^1.0",
+        "psr/http-factory": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Psr17/MessageFactory.php
+++ b/src/Psr17/MessageFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Http\Message\Psr17;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Compatibility layer for PSR-17 reqeust and response factory.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class MessageFactory implements \Http\Message\MessageFactory
+{
+    /**
+     * @var \Http\Message\ResponseFactory
+     */
+    private $requestFactory;
+
+    /**
+     * @var \Http\Message\ResponseFactory
+     */
+    private $responseFactory;
+
+    public function __construct(
+        RequestFactoryInterface $requestFactory,
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory
+    ) {
+        $this->requestFactory = new RequestFactory($requestFactory, $streamFactory);
+        $this->responseFactory = new ResponseFactory($responseFactory, $streamFactory);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+    {
+        return $this->requestFactory->createRequest($method, $uri, $headers, $body, $protocolVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $protocolVersion = '1.1')
+    {
+        return $this->responseFactory->createResponse($statusCode, $reasonPhrase, $headers, $body, $protocolVersion);
+    }
+}

--- a/src/Psr17/RequestFactory.php
+++ b/src/Psr17/RequestFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Http\Message\Psr17;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Compatibility layer for PSR-17 request factory.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class RequestFactory implements \Http\Message\RequestFactory
+{
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
+     * @var \Http\Message\StreamFactory
+     */
+    private $streamFactory;
+
+    public function __construct(RequestFactoryInterface $requestFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = new StreamFactory($streamFactory);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createRequest($method, $uri, array $headers = [], $body = null, $protocolVersion = '1.1')
+    {
+        $request = $this->requestFactory
+            ->createRequest($method, $uri)
+            ->withBody($this->streamFactory->createStream($body))
+            ->withProtocolVersion($protocolVersion)
+        ;
+
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
+    }
+}

--- a/src/Psr17/ResponseFactory.php
+++ b/src/Psr17/ResponseFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Http\Message\Psr17;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Compatibility layer for PSR-17 response factory.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class ResponseFactory implements \Http\Message\ResponseFactory
+{
+    /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @var \Http\Message\StreamFactory
+     */
+    private $streamFactory;
+
+    public function __construct(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = new StreamFactory($streamFactory);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createResponse($statusCode = 200, $reasonPhrase = null, array $headers = [], $body = null, $protocolVersion = '1.1')
+    {
+        $response = $this->responseFactory
+            ->createResponse($statusCode, (string) $reasonPhrase)
+            ->withBody($this->streamFactory->createStream($body))
+            ->withProtocolVersion($protocolVersion)
+        ;
+
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response;
+    }
+}

--- a/src/Psr17/StreamFactory.php
+++ b/src/Psr17/StreamFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Http\Message\Psr17;
+
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Compatibility layer for PSR-17 stream factory.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class StreamFactory implements \Http\Message\StreamFactory
+{
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    public function __construct(StreamFactoryInterface $streamFactory)
+    {
+        $this->streamFactory = $streamFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createStream($body = null)
+    {
+        if ($body instanceof StreamInterface) {
+            return $body;
+        }
+
+        if (is_resource($body)) {
+            return $this->streamFactory->createStreamFromResource($body);
+        }
+
+        return $this->streamFactory->createStream((string) $body);
+    }
+}

--- a/src/Psr17/UriFactory.php
+++ b/src/Psr17/UriFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Http\Message\Psr17;
+
+use Psr\Http\Message\UriFactoryInterface;
+
+/**
+ * Compatibility layer for PSR-17 URI factory.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class UriFactory implements \Http\Message\UriFactory
+{
+    /**
+     * @var UriFactoryInterface
+     */
+    private $uriFactory;
+
+    public function __construct(UriFactoryInterface $uriFactory)
+    {
+        $this->uriFactory = $uriFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createUri($uri)
+    {
+        return $this->uriFactory->createUri($uri);
+    }
+}


### PR DESCRIPTION
This PR adds a compatibility layer between our message factories and PSR-17. Once it is in place, we can refactor the discovery layer to check for PSR-17 implementations and use them instead of requiring the `php-http/message` package.

After that we can deprecate the implementations of our message factories and the interfaces themselves, eventually migrating to PSR-17 interfaces. Maybe we can do it before tagging client-common 2.0?

## Todo

- [ ] Add tests (anyone up for it?)