### PR TITLE
Deprecate all interfaces in favor of PSR-17 and allow `psr/http-message` v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## 1.1.0 - Unreleased
+
+### Changed
+
+- Allow `psr/http-message` v2 in addition to v1
+- Deprecate all interfaces in favor of [PSR-17](https://www.php-fig.org/psr/psr-17/)
+
 ## 1.0.2 - 2015-12-19
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/src/MessageFactory.php
+++ b/src/MessageFactory.php
@@ -6,6 +6,8 @@ namespace Http\Message;
  * Factory for PSR-7 Request and Response.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @deprecated since version 1.1, use Psr\Http\Message\RequestFactoryInterface and Psr\Http\Message\ResponseFactoryInterface instead.
  */
 interface MessageFactory extends RequestFactory, ResponseFactory
 {

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\StreamInterface;
  * Factory for PSR-7 Request.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @deprecated since version 1.1, use Psr\Http\Message\RequestFactoryInterface instead.
  */
 interface RequestFactory
 {

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -11,6 +11,8 @@ use Psr\Http\Message\StreamInterface;
  * This factory contract can be reused in Message and Server Message factories.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @deprecated since version 1.1, use Psr\Http\Message\ResponseFactoryInterface instead.
  */
 interface ResponseFactory
 {

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -8,6 +8,8 @@ use Psr\Http\Message\StreamInterface;
  * Factory for PSR-7 Stream.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @deprecated since version 1.1, use Psr\Http\Message\StreamFactoryInterface instead.
  */
 interface StreamFactory
 {

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -8,6 +8,8 @@ use Psr\Http\Message\UriInterface;
  * Factory for PSR-7 URI.
  *
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ *
+ * @deprecated since version 1.1, use Psr\Http\Message\UriFactoryInterface instead.
  */
 interface UriFactory
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | -
| Documentation   | TBD
| License         | MIT

